### PR TITLE
fix(dynamodb): address remaining audit findings H-Q13, H-TQ2, H-D2, m…

### DIFF
--- a/src/dynamodb/DBS.ts
+++ b/src/dynamodb/DBS.ts
@@ -50,8 +50,9 @@ class DBS extends Queriable implements GenericDBS {
   }
 
   async shutdown(): Promise<void> {
+    // DynamoDBDocumentClient wraps DynamoDBClient; destroying the document
+    // client disposes the underlying raw client too.
     this._client.destroy();
-    this._raw.destroy();
   }
 }
 

--- a/src/dynamodb/Query.test.ts
+++ b/src/dynamodb/Query.test.ts
@@ -146,6 +146,20 @@ runOrSkip("DynamoDB Query CRUD", () => {
     expect(res.rowCount).toBe(0);
   });
 
+  test("remove with >25 ids exercises the 25-item chunking loop", async () => {
+    const ids = Array.from({ length: 26 }, (_, i) => `chunk-${i}`);
+    await dbs
+      .collection(TEST_TABLE)
+      .insert(ids.map((id) => ({ id })));
+    const res = await dbs.collection(TEST_TABLE).remove({ id: ids });
+    expect(res.rowCount).toBe(26);
+    const remaining = await dbs
+      .collection(TEST_TABLE)
+      .findByIds({ id: ids })
+      .toArray();
+    expect(remaining).toEqual([]);
+  });
+
   test("insert rejects duplicate primary keys with _code: 1", async () => {
     await dbs.collection(TEST_TABLE).insert([{ id: "dup", number: 1 }]);
     await expect(

--- a/src/dynamodb/Query.ts
+++ b/src/dynamodb/Query.ts
@@ -20,6 +20,11 @@ import {
   Result,
 } from "../generic";
 import { DynamoConfig } from "./Config";
+import {
+  isSinglePrimaryKeyLookup,
+  namePlaceholder,
+  valuePlaceholder,
+} from "./filterHelpers";
 import { LogFunc } from "./types";
 
 export const isConditionalCheckFailed = (e: unknown): boolean =>
@@ -51,24 +56,6 @@ type OperatorResult =
   | { kind: "always_true" };
 
 const PK = "id";
-
-const namePlaceholder = (
-  attr: string,
-  attrNames: Record<string, string>
-): string => {
-  const key = `#n${Object.keys(attrNames).length}`;
-  attrNames[key] = attr;
-  return key;
-};
-
-const valuePlaceholder = (
-  value: unknown,
-  attrValues: Record<string, unknown>
-): string => {
-  const key = `:v${Object.keys(attrValues).length}`;
-  attrValues[key] = value;
-  return key;
-};
 
 const buildOperator = (
   attr: string,
@@ -176,7 +163,9 @@ export const buildFilterExpression = (params: Params): FilterExprResult => {
     const val = params[key];
     if (val === null) {
       const n = namePlaceholder(key, attrNames);
-      clauses.push(`attribute_not_exists(${n})`);
+      // Match both "attribute absent" and "attribute stored as DynamoDB NULL".
+      const v = valuePlaceholder(null, attrValues);
+      clauses.push(`(attribute_not_exists(${n}) OR ${n} = ${v})`);
       continue;
     }
     if (typeof val !== "object") {
@@ -207,17 +196,6 @@ export const buildFilterExpression = (params: Params): FilterExprResult => {
     attrNames,
     attrValues,
   };
-};
-
-const isSinglePrimaryKeyLookup = (
-  params: Params
-): { hit: boolean; key?: string | number } => {
-  const keys = Object.keys(params);
-  if (keys.length !== 1 || keys[0] !== PK) return { hit: false };
-  const v = params[PK];
-  if (v === null) return { hit: false };
-  if (typeof v === "object") return { hit: false };
-  return { hit: true, key: v as string | number };
 };
 
 const extractPrimaryKeyList = (

--- a/src/dynamodb/TransactionQuery.ts
+++ b/src/dynamodb/TransactionQuery.ts
@@ -1,6 +1,11 @@
 import { TransactWriteCommandInput } from "@aws-sdk/lib-dynamodb";
 
 import { Id, NotSupportedByDBEngine, Order, Params, Result } from "../generic";
+import {
+  isSinglePrimaryKeyLookup,
+  namePlaceholder,
+  valuePlaceholder,
+} from "./filterHelpers";
 import Query from "./Query";
 
 export type TransactItem = NonNullable<
@@ -17,35 +22,6 @@ const REJECT_READ = () =>
   new NotSupportedByDBEngine(
     "Reads inside a DynamoDB transaction are not supported - the buffered writes are not visible to Scan/Get until commit(). Commit the transaction and read via the outer DBS."
   );
-
-const isSinglePrimaryKeyLookup = (
-  params: Params
-): { hit: boolean; key?: string | number } => {
-  const keys = Object.keys(params);
-  if (keys.length !== 1 || keys[0] !== PK) return { hit: false };
-  const v = params[PK];
-  if (v === null) return { hit: false };
-  if (typeof v === "object") return { hit: false };
-  return { hit: true, key: v as string | number };
-};
-
-const namePlaceholder = (
-  attr: string,
-  attrNames: Record<string, string>
-): string => {
-  const key = `#n${Object.keys(attrNames).length}`;
-  attrNames[key] = attr;
-  return key;
-};
-
-const valuePlaceholder = (
-  value: unknown,
-  attrValues: Record<string, unknown>
-): string => {
-  const key = `:v${Object.keys(attrValues).length}`;
-  attrValues[key] = value;
-  return key;
-};
 
 class TransactionQuery extends Query {
   _writes: TransactItem[];

--- a/src/dynamodb/filterExpression.test.ts
+++ b/src/dynamodb/filterExpression.test.ts
@@ -19,13 +19,13 @@ describe("buildFilterExpression", () => {
     expect(r.attrValues).toEqual({ ":v0": "x" });
   });
 
-  test("null shorthand renders attribute_not_exists and allocates no value", () => {
+  test("null shorthand renders (attribute_not_exists OR = null) to match absent and NULL-typed attributes", () => {
     const r = buildFilterExpression(p({ foo: null }));
     expect(r.kind).toBe("expr");
     if (r.kind !== "expr") return;
-    expect(r.expr).toBe("attribute_not_exists(#n0)");
+    expect(r.expr).toBe("(attribute_not_exists(#n0) OR #n0 = :v0)");
     expect(r.attrNames).toEqual({ "#n0": "foo" });
-    expect(r.attrValues).toEqual({});
+    expect(r.attrValues).toEqual({ ":v0": null });
   });
 
   test("bare array on non-PK renders IN with placeholders", () => {

--- a/src/dynamodb/filterHelpers.ts
+++ b/src/dynamodb/filterHelpers.ts
@@ -1,0 +1,32 @@
+import { Params } from "../generic";
+
+const PK = "id";
+
+export const namePlaceholder = (
+  attr: string,
+  attrNames: Record<string, string>
+): string => {
+  const key = `#n${Object.keys(attrNames).length}`;
+  attrNames[key] = attr;
+  return key;
+};
+
+export const valuePlaceholder = (
+  value: unknown,
+  attrValues: Record<string, unknown>
+): string => {
+  const key = `:v${Object.keys(attrValues).length}`;
+  attrValues[key] = value;
+  return key;
+};
+
+export const isSinglePrimaryKeyLookup = (
+  params: Params
+): { hit: boolean; key?: string | number } => {
+  const keys = Object.keys(params);
+  if (keys.length !== 1 || keys[0] !== PK) return { hit: false };
+  const v = params[PK];
+  if (v === null) return { hit: false };
+  if (typeof v === "object") return { hit: false };
+  return { hit: true, key: v as string | number };
+};


### PR DESCRIPTION
…issing remove-chunk test

H-Q13: null filter now emits (attribute_not_exists(#n) OR #n = :null) so rows where an attribute is stored as DynamoDB NULL-type are also matched, not just rows where the attribute is absent.

H-TQ2: extract namePlaceholder, valuePlaceholder, isSinglePrimaryKeyLookup into src/dynamodb/filterHelpers.ts; import from both Query.ts and TransactionQuery.ts so future fixes only need one edit.

H-D2: remove redundant this._raw.destroy() in DBS.shutdown() — destroying the DynamoDBDocumentClient already disposes the underlying DynamoDBClient.

test: add remove-with->25-ids integration test to exercise the 25-item chunk loop in Query.remove (previously only 3 ids were tested).

https://claude.ai/code/session_01NfipBjgxCvXcrvcoFkKGPA